### PR TITLE
[fix] Remove empty lines while copying code from web UI.

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -6,10 +6,10 @@ body {
 
 }
 
-* { 
-	-moz-box-sizing: border-box; 
-	-webkit-box-sizing: border-box; 
-	box-sizing: border-box; 
+* {
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 .container {
@@ -23,13 +23,13 @@ body {
 
 }
 
-pre, code {
+code, #snippet {
 
 	margin: 0;
 
 }
 
-pre {
+.loc, #snippet {
 	width: 100%;
 	white-space: pre;
 	word-wrap: normal;
@@ -84,7 +84,13 @@ td.line-number {
 
 	background: #111;
 	text-align: right;
-
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	-o-user-select:none;
+	user-select: none;
 }
 
 td.line-number:hover {
@@ -98,7 +104,6 @@ td.line-number::before {
 
 	content: attr(data-line-number);
 	padding-right: 1em;
-
 }
 
 .helper {
@@ -184,16 +189,16 @@ footer {
 @media screen and (max-width: 720px) {
 
 	.controls {
-	
+
 		flex: 1;
-	
+
 	}
-	
+
 	.content {
-	
+
 		flex: 5;
 		height: 100%;
-	
+
 	}
 
 	.footer-text {

--- a/render/components/highlight.js
+++ b/render/components/highlight.js
@@ -1,8 +1,8 @@
 const hl = require('highlight.js');
 
 module.exports = (m, { content = '', language }) => {
-	return m('table', 
-		m('tbody', 
+	return m('table',
+		m('tbody',
 			hl
 				.highlightAuto(((content || "") + "\n\n"), language)
 				.value
@@ -10,7 +10,7 @@ module.exports = (m, { content = '', language }) => {
 				.map((line, index) => m('tr', [
 						m('td.line-number',
 							{ 'id': `L${index}`, 'data-line-number': index }),
-						m('td', m.trust(`<pre>${line}</pre>`)),
+						m('td', m.trust(`<code class="loc">${line}</code>`)),
 					]))
 		),
 	);

--- a/render/components/mainContent.js
+++ b/render/components/mainContent.js
@@ -4,7 +4,7 @@ module.exports = (m, { location, content, language }) => {
 	language = language && [ language ];
 	const isSnippet = location === 'snippet';
 	const textArea =
-		(isSnippet ? "pre" : "textarea.binEditor")
+		(isSnippet ? "code" : "textarea.binEditor")
 			+ "#snippet.textarea"
 			+ (language ? "." + language : "");
 	const highlighted =
@@ -27,7 +27,7 @@ module.exports = (m, { location, content, language }) => {
 					highlighted || content
 				)
 			),
-			(isSnippet && 
+			(isSnippet &&
 				m(
 					'textarea#originalSnippet',
 					{


### PR DESCRIPTION
Replace pre with code. Add `user-select: none` to disallow copying line numbers.